### PR TITLE
JSON Reader Updates

### DIFF
--- a/src/codeu/chat/server/JSON.java
+++ b/src/codeu/chat/server/JSON.java
@@ -1,5 +1,6 @@
 package codeu.chat.server;
 import codeu.chat.common.ConversationHeader;
+import codeu.chat.common.ConversationPayload;
 import codeu.chat.common.Message;
 import codeu.chat.common.User;
 
@@ -68,141 +69,182 @@ public final class JSON {
             // will be used and returned.
             System.out.println("Invalid file");
         }
-       if (jp!=null) {
+        if (jp!=null) {
             // If the file exists, then the file will be parsed
-           // in this set of code
-           jp.nextToken();
+            // in this set of code
+            jp.nextToken();
             while (jp.nextToken() != JsonToken.END_OBJECT)
             // This ensures that we haven't reached the end of the
             // file because the data is being parsed in such a way
             // that this END_OBJECT specifically relates to the
             // very last } in the json file
             {
-            if(jp.getText().equals("users")) {
-                // If the object type represents a User, then
-                // specific steps will take place to create
-                // a User variable
-                jp.nextToken();
-                while (jp.nextToken() != JsonToken.END_ARRAY) {
+                if(jp.getText().equals("users")) {
+                    // If the object type represents a User, then
+                    // specific steps will take place to create
+                    // a User variable
+                    //jp.nextToken();
+                    Time time = null;
                     String name = "";
                     Uuid id = null;
-                    Time time = null;
-                    jp.nextToken();
-                    if (jp.getText().equals("name")) {
-                        jp.nextToken();
-                        name = jp.getText();
-                    }
-                    jp.nextToken();
-                    if (jp.getText().equals("uuid")) {
-                        jp.nextToken();
-                        try {
-                            id = Uuid.parse(jp.getText());
-                        } catch (IOException e) {
-                            System.out.println("Invalid Uuid");
+                    while (jp.nextToken() != JsonToken.END_ARRAY) {
+                        if (jp.getText().equals("name")) {
+                            jp.nextToken();
+                            name = jp.getText();
+                            //jp.nextToken();
+                        }
+                        if (jp.getText().equals("uuid")) {
+                            jp.nextToken();
+                            try {
+                                id = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                            //jp.nextToken();
+                        }
+                        if (jp.getText().equals("creationTime")) {
+                            jp.nextToken();
+                            time = Time.fromMs(jp.getLongValue());
+                            //jp.nextToken();
+                        }
+                        if (!(name.equals("")) && time != null && id != null) {
+                            model.add(new User(id, name, time));
+                            name = "";
+                            time = null;
+                            id = null;
                         }
                     }
-                    jp.nextToken();
-                    if (jp.getText().equals("creationTime")) {
-                        jp.nextToken();
-                        time = Time.fromMs(jp.getLongValue());
-                    }
-                    jp.nextToken();
-                    if (!(name.equals("")) && time != null && id != null)
-                        model.add(new User(id, name, time));
+                    continue;
                 }
-                continue;
-            }
-            if(jp.getText().equals("conversations"))
-            {
-                // If the object type represents a Conversation, then
-                // specific steps will take place to create
-                // a ConversationHeader variable
-                jp.nextToken();
-                while(jp.nextToken()!=JsonToken.END_ARRAY) {
+                if(jp.getText().equals("conversations"))
+                {
+                    // If the object type represents a Conversation, then
+                    // specific steps will take place to create
+                    // a ConversationHeader variable
                     Uuid id = null;
                     Uuid owner = null;
                     Time creation = null;
                     String title = "";
-                    jp.nextToken();
-                    if (jp.getText().equals("title")) {
-                        jp.nextToken();
-                        title = jp.getText();
-                    }
-                    jp.nextToken();
-                    if (jp.getText().equals("uuid")) {
-                        jp.nextToken();
-                        try {
-                            id = Uuid.parse(jp.getText());
-                        } catch (IOException e) {
-                            System.out.println("Invalid Uuid");
+                    Uuid last = null;
+                    Uuid first = null;
+                    while(jp.nextToken()!=JsonToken.END_ARRAY) {
+                        if (jp.getText().equals("title")) {
+                            jp.nextToken();
+                            title = jp.getText();
+                        }
+                        if (jp.getText().equals("uuid")) {
+                            jp.nextToken();
+                            try {
+                                id = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("ownerUUID")) {
+                            jp.nextToken();
+                            try {
+                                owner = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("firstMessageUUID")) {
+                            jp.nextToken();
+                            try {
+                                first = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("lastMessageUUID")) {
+                            jp.nextToken();
+                            try {
+                                last = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("creationTime")) {
+                            jp.nextToken();
+                            creation = Time.fromMs(jp.getLongValue());
+                        }
+                        if (!(title.equals("")) && id != null && owner != null && creation != null && last!=null && first!=null) {
+                            model.add(new ConversationHeader(id, owner, creation, title), new ConversationPayload(id,first,last));
+                            title = "";
+                            id= null;
+                            owner = null;
+                            creation = null;
+                            first = null;
+                            last = null;
                         }
                     }
-                    jp.nextToken();
-                    if (jp.getText().equals("ownerUUID")) {
-                        jp.nextToken();
-                        try {
-                            owner = Uuid.parse(jp.getText());
-                        } catch (IOException e) {
-                            System.out.println("Invalid Uuid");
-                        }
-                    }
-                    jp.nextToken();
-                    if (jp.getText().equals("creationTime")) {
-                        jp.nextToken();
-                        creation = Time.fromMs(jp.getLongValue());
-                    }
-                    jp.nextToken();
-                    if (!(title.equals("")) && id != null && owner != null && creation != null)
-                        model.add(new ConversationHeader(id, owner, creation, title));
+                    continue;
                 }
-                continue;
-            }
-            if(jp.getText().equals("messages")) {
-                // If the object type represents a Message, then
-                // specific steps will take place to create
-                // a Message variable
-                jp.nextToken();
-                while (jp.nextToken() != JsonToken.END_ARRAY) {
-                    Uuid id = null;
-                    Uuid owner = null;
-                    Time creation = null;
-                    String body = "";
-                    jp.nextToken();
-                    if (jp.getText().equals("content")) {
-                        jp.nextToken();
-                        body = jp.getText();
-                    }
-                    jp.nextToken();
-                    if (jp.getText().equals("uuid")) {
-                        jp.nextToken();
-                        try {
-                            id = Uuid.parse(jp.getText());
-                        } catch (IOException e) {
-                            System.out.println("Invalid Uuid");
+                if(jp.getText().equals("messages")) {
+                    // If the object type represents a Message, then
+                    // specific steps will take place to create
+                    // a Message variable
+                      Uuid id = null;
+                      Uuid owner = null;
+                      Time creation = null;
+                      String body = "";
+                      Uuid next = null;
+                      Uuid previous = null;
+                    while (jp.nextToken() != JsonToken.END_ARRAY) {
+                        if (jp.getText().equals("content")) {
+                            jp.nextToken();
+                            body = jp.getText();
+                        }
+                        if (jp.getText().equals("uuid")) {
+                            jp.nextToken();
+                            try {
+                                id = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("authorUUID")) {
+                            jp.nextToken();
+                            try {
+                                owner = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("creationTime")) {
+                            jp.nextToken();
+                            creation = Time.fromMs(jp.getLongValue());
+                        }
+                        if (jp.getText().equals("nextUUID")) {
+                            jp.nextToken();
+                            try {
+                                next = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (jp.getText().equals("previousUUID")) {
+                            jp.nextToken();
+                            try {
+                                previous = Uuid.parse(jp.getText());
+                            } catch (IOException e) {
+                                System.out.println("Invalid Uuid");
+                            }
+                        }
+                        if (!(body.equals("")) && id != null && owner != null && creation != null && previous!=null && next!=null) {
+                            model.add(new Message(id, next, previous, creation, owner, body));
+                            body = "";
+                            id = null;
+                            owner = null;
+                            creation = null;
+                            next = null;
+                            previous = null;
                         }
                     }
-                    jp.nextToken();
-                    if (jp.getText().equals("authorUUID")) {
-                        jp.nextToken();
-                        try {
-                            owner = Uuid.parse(jp.getText());
-                        } catch (IOException e) {
-                            System.out.println("Invalid Uuid");
-                        }
-                    }
-                    jp.nextToken();
-                    if (jp.getText().equals("creationTime")) {
-                        jp.nextToken();
-                        creation = Time.fromMs(jp.getLongValue());
-                    }
-                    jp.nextToken();
-                    if (!(body.equals("")) && id != null && owner != null && creation != null)
-                        model.add(new Message(id, Uuid.NULL, Uuid.NULL, creation, owner, body));
                 }
             }
-           }
-           jp.close();
-       }
+            jp.close();
+        }
         return model;
     }
 }

--- a/src/codeu/chat/server/JSON.java
+++ b/src/codeu/chat/server/JSON.java
@@ -91,7 +91,6 @@ public final class JSON {
                         if (jp.getText().equals("name")) {
                             jp.nextToken();
                             name = jp.getText();
-                            //jp.nextToken();
                         }
                         if (jp.getText().equals("uuid")) {
                             jp.nextToken();
@@ -100,12 +99,10 @@ public final class JSON {
                             } catch (IOException e) {
                                 System.out.println("Invalid Uuid");
                             }
-                            //jp.nextToken();
                         }
                         if (jp.getText().equals("creationTime")) {
                             jp.nextToken();
                             time = Time.fromMs(jp.getLongValue());
-                            //jp.nextToken();
                         }
                         if (!(name.equals("")) && time != null && id != null) {
                             model.add(new User(id, name, time));

--- a/src/codeu/chat/server/Model.java
+++ b/src/codeu/chat/server/Model.java
@@ -92,6 +92,14 @@ public final class Model {
     conversationPayloadById.insert(conversation.id, new ConversationPayload(conversation.id));
   }
 
+  public void add(ConversationHeader conversation, ConversationPayload conversationPayLoad) {
+    conversationById.insert(conversation.id, conversation);
+    conversationByTime.insert(conversation.creation, conversation);
+    conversationByText.insert(conversation.title, conversation);
+    conversationPayloadById.insert(conversation.id, conversationPayLoad);
+  }
+
+
   public StoreAccessor<Uuid, ConversationHeader> conversationById() {
     return conversationById;
   }

--- a/test/codeu/chat/server/JSONTest.java
+++ b/test/codeu/chat/server/JSONTest.java
@@ -2,6 +2,7 @@ package codeu.chat.server;
 import static org.junit.Assert.*;
 
 import codeu.chat.common.ConversationHeader;
+import codeu.chat.common.ConversationPayload;
 import codeu.chat.common.Message;
 import codeu.chat.common.ServerInfo;
 import codeu.chat.common.User;
@@ -30,9 +31,8 @@ public class JSONTest {
         JSON log = new JSON();
         Model expected = new Model();
         expected.add(new User(createUuid("1.1074501217"), "Krager", Time.fromMs(4309509)));
-        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59408509), "Chat1"));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59408509), "Chat1"), new ConversationPayload( createUuid("1.3959833157"), createUuid("1.3350517446"), createUuid("1.1516759239")));
         expected.add(new Message(createUuid("1.3928689216"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(49584908), createUuid("1.1074501217"),   "I'm so alone"));
-
         try {
             // Path used by Priyanka:
             model = log.readFromFile("/Users/HMCLoaner/Desktop/CodeU/test/codeu/chat/server/input.json");
@@ -91,8 +91,8 @@ public class JSONTest {
         Model expected = new Model();
         expected.add(new User(createUuid("1.1074501217"), "Krager", Time.fromMs(4098590)));
         expected.add(new User(createUuid("1.3566231147"), "FakeUserName1234", Time.fromMs(48574)));
-        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(98094), "Chat1"));
-        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59485), "Chat2"));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(98094), "Chat1"), new ConversationPayload( createUuid("1.3959833157"), createUuid("1.3350517446"), createUuid("1.1516759239")));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59485), "Chat2"), new ConversationPayload( createUuid("1.3959833157"), createUuid("1.3350517446"), createUuid("1.1516759239")));
         expected.add(new Message(createUuid("1.3928689216"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(49589), createUuid("1.1074501217"),   "I'm so alone"));
         expected.add(new Message(createUuid("1.2016074193"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(9485), createUuid("1.1074501217"),   "I need friends"));
         expected.add(new Message(createUuid("1.384992272"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(5098), createUuid("1.1074501217"),   "Julia'sFixesAreNotImplementedYetCanYouTell?"));
@@ -174,13 +174,14 @@ public class JSONTest {
     @Test
     public void orderDoesntMatter() {
         // This function tests if the JSON reader is working if there is a JSON with multiple types of each object in the file
+        // This also has the fields in a variety of orders to make sure that the order doesn't affect it.
         JSON log = new JSON();
         Model model = new Model();
         Model expected = new Model();
         expected.add(new User(createUuid("1.1074501217"), "Krager", Time.fromMs(4098590)));
         expected.add(new User(createUuid("1.3566231147"), "FakeUserName1234", Time.fromMs(48574)));
-        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(98094), "Chat1"));
-        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59485), "Chat2"));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(98094), "Chat1"), new ConversationPayload( createUuid("1.3959833157"), createUuid("1.3350517446"), createUuid("1.1516759239")));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59485), "Chat2"), new ConversationPayload( createUuid("1.3959833157"), createUuid("1.3350517446"), createUuid("1.1516759239")));
         expected.add(new Message(createUuid("1.3928689216"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(49589), createUuid("1.1074501217"),   "I'm so alone"));
         expected.add(new Message(createUuid("1.2016074193"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(9485), createUuid("1.1074501217"),   "I need friends"));
         expected.add(new Message(createUuid("1.384992272"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(5098), createUuid("1.1074501217"),   "Julia'sFixesAreNotImplementedYetCanYouTell?"));

--- a/test/codeu/chat/server/JSONTest.java
+++ b/test/codeu/chat/server/JSONTest.java
@@ -31,7 +31,7 @@ public class JSONTest {
         Model expected = new Model();
         expected.add(new User(createUuid("1.1074501217"), "Krager", Time.fromMs(4309509)));
         expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59408509), "Chat1"));
-        expected.add(new Message(createUuid("1.3928689216"), Uuid.NULL, Uuid.NULL, Time.fromMs(49584908), createUuid("1.1074501217"),   "I'm so alone"));
+        expected.add(new Message(createUuid("1.3928689216"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(49584908), createUuid("1.1074501217"),   "I'm so alone"));
 
         try {
             // Path used by Priyanka:
@@ -93,9 +93,9 @@ public class JSONTest {
         expected.add(new User(createUuid("1.3566231147"), "FakeUserName1234", Time.fromMs(48574)));
         expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(98094), "Chat1"));
         expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59485), "Chat2"));
-        expected.add(new Message(createUuid("1.3928689216"), Uuid.NULL, Uuid.NULL, Time.fromMs(49589), createUuid("1.1074501217"),   "I'm so alone"));
-        expected.add(new Message(createUuid("1.2016074193"), Uuid.NULL, Uuid.NULL, Time.fromMs(9485), createUuid("1.1074501217"),   "I need friends"));
-        expected.add(new Message(createUuid("1.384992272"), Uuid.NULL, Uuid.NULL, Time.fromMs(5098), createUuid("1.1074501217"),   "Julia'sFixesAreNotImplementedYetCanYouTell?"));
+        expected.add(new Message(createUuid("1.3928689216"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(49589), createUuid("1.1074501217"),   "I'm so alone"));
+        expected.add(new Message(createUuid("1.2016074193"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(9485), createUuid("1.1074501217"),   "I need friends"));
+        expected.add(new Message(createUuid("1.384992272"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(5098), createUuid("1.1074501217"),   "Julia'sFixesAreNotImplementedYetCanYouTell?"));
 
         try {
             // Path used by Priyanka:
@@ -153,6 +153,7 @@ public class JSONTest {
                 compare(model.userByTime().all().iterator(), expected.userByTime().all().iterator()), false);
     }
 
+    @Test
     public void errorThrown() {
         // This function tests is an error is thrown properly if the file can't be properly read
         JSON log = new JSON();
@@ -168,6 +169,32 @@ public class JSONTest {
             errorThrown = true;
         }
         assertTrue(errorThrown);
+    }
+
+    @Test
+    public void orderDoesntMatter() {
+        // This function tests if the JSON reader is working if there is a JSON with multiple types of each object in the file
+        JSON log = new JSON();
+        Model model = new Model();
+        Model expected = new Model();
+        expected.add(new User(createUuid("1.1074501217"), "Krager", Time.fromMs(4098590)));
+        expected.add(new User(createUuid("1.3566231147"), "FakeUserName1234", Time.fromMs(48574)));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(98094), "Chat1"));
+        expected.add(new ConversationHeader(createUuid("1.3959833157"), createUuid("1.1074501217"),  Time.fromMs(59485), "Chat2"));
+        expected.add(new Message(createUuid("1.3928689216"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(49589), createUuid("1.1074501217"),   "I'm so alone"));
+        expected.add(new Message(createUuid("1.2016074193"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(9485), createUuid("1.1074501217"),   "I need friends"));
+        expected.add(new Message(createUuid("1.384992272"), createUuid("1.1516759239"), createUuid("0"), Time.fromMs(5098), createUuid("1.1074501217"),   "Julia'sFixesAreNotImplementedYetCanYouTell?"));
+
+        try {
+            // Path used by Priyanka:
+            model = log.readFromFile("/Users/HMCLoaner/Desktop/CodeU/test/codeu/chat/server/input6.json");
+            // The path can vary from device, so this may not compile if it's not the correct path for your project
+            // set up. A suggested path is as follows
+            //model = log.readFromFile("CodeU/test/codeu/chat/server/input4.json");
+        } catch (IOException e) {
+            System.out.println("File not handled properly");
+        }
+        compareModels(model,expected);
     }
 
     public Uuid createUuid(String id)

--- a/test/codeu/chat/server/input.json
+++ b/test/codeu/chat/server/input.json
@@ -10,12 +10,16 @@
       "title": "Chat1",
       "uuid": "1.3959833157",
       "ownerUUID": "1.1074501217",
-      "creationTime": 59408509
+      "creationTime": 59408509,
+      "firstMessageUUID" : "1.3350517446",
+      "lastMessageUUID" : "1.1516759239"
     }],
   "messages" : [ {
     "content" : "I'm so alone",
     "uuid" : "1.3928689216",
     "authorUUID" : "1.1074501217",
-    "creationTime" : 49584908
+    "creationTime" : 49584908,
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0",
   }]
 }

--- a/test/codeu/chat/server/input.json
+++ b/test/codeu/chat/server/input.json
@@ -20,6 +20,6 @@
     "authorUUID" : "1.1074501217",
     "creationTime" : 49584908,
     "nextUUID" : "1.1516759239",
-    "previousUUID" : "0",
+    "previousUUID" : "0"
   }]
 }

--- a/test/codeu/chat/server/input4.json
+++ b/test/codeu/chat/server/input4.json
@@ -12,27 +12,37 @@
     "title" : "Chat1",
     "uuid" : "1.3959833157",
     "ownerUUID" : "1.1074501217",
-    "creationTime" : 98094
+    "creationTime" : 98094,
+    "firstMessageUUID" : "1.3350517446",
+    "lastMessageUUID" : "1.1516759239"
   }, {
     "title" : "Chat2",
     "uuid" : "1.3959833157",
     "ownerUUID" : "1.1074501217",
-    "creationTime" : 59485
+    "creationTime" : 59485,
+    "firstMessageUUID" : "1.3350517446",
+    "lastMessageUUID" : "1.1516759239"
   } ],
   "messages" : [ {
     "content" : "I'm so alone",
     "uuid" : "1.3928689216",
     "authorUUID" : "1.1074501217",
-    "creationTime" : 49589
+    "creationTime" : 49589,
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0"
   }, {
     "content" : "I need friends",
     "uuid" : "1.2016074193",
     "authorUUID" : "1.1074501217",
-    "creationTime" : 9485
+    "creationTime" : 9485,
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0"
   }, {
     "content" : "Julia'sFixesAreNotImplementedYetCanYouTell?",
     "uuid" : "1.384992272",
     "authorUUID" : "1.1074501217",
-    "creationTime" : 5098
+    "creationTime" : 5098,
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0"
   } ]
 }

--- a/test/codeu/chat/server/input6.json
+++ b/test/codeu/chat/server/input6.json
@@ -1,0 +1,48 @@
+{
+  "users" : [ {
+    "uuid" : "1.1074501217",
+    "name" : "Krager",
+    "creationTime" : 4098590
+  }, {
+    "name" : "FakeUserName1234",
+    "uuid" : "1.3566231147",
+    "creationTime" : 48574
+  } ],
+  "conversations" : [ {
+    "title" : "Chat1",
+    "uuid" : "1.3959833157",
+    "ownerUUID" : "1.1074501217",
+    "creationTime" : 98094,
+    "firstMessageUUID" : "1.3350517446",
+    "lastMessageUUID" : "1.1516759239"
+  }, {
+    "title" : "Chat2",
+    "uuid" : "1.3959833157",
+    "creationTime" : 59485,
+    "ownerUUID" : "1.1074501217",
+    "firstMessageUUID" : "1.3350517446",
+    "lastMessageUUID" : "1.1516759239"
+  } ],
+  "messages" : [ {
+    "content" : "I'm so alone",
+    "authorUUID" : "1.1074501217",
+    "creationTime" : 49589,
+    "uuid" : "1.3928689216",
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0"
+  }, {
+    "authorUUID" : "1.1074501217",
+    "content" : "I need friends",
+    "uuid" : "1.2016074193",
+    "creationTime" : 9485,
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0"
+  }, {
+    "uuid" : "1.384992272",
+    "authorUUID" : "1.1074501217",
+    "content" : "Julia'sFixesAreNotImplementedYetCanYouTell?",
+    "creationTime" : 5098,
+    "nextUUID" : "1.1516759239",
+    "previousUUID" : "0"
+  } ]
+}


### PR DESCRIPTION
This code has a couple of updates to the current way the JSON is being read. To begin, it now doesn't depend on the order of the fields being consistent. Previously, I'd written the code to make order matter under the assumption that the order will always be constant. However, now with the possibility of having the order changed when the objects were written to JSON, I had to update the code so that the data could still be read. There were also problems because m-list didn't return the messages inside of the conversation properly. This stemmed from the fact that messages weren't being linked to each other or to conversations. By using conversationPayLoad and using the next and previous fields in Message, this problem was fixed. 